### PR TITLE
Can select 1st category

### DIFF
--- a/qa-cat-desc-lang-default.php
+++ b/qa-cat-desc-lang-default.php
@@ -4,4 +4,5 @@ return array(
 	'edit_desc_for_x' => 'Edit the description for ^',
 	'save_desc_button' => 'Save Description',
 	'create_desc_link' => 'Create category description',
+	'select' => 'Select',
 );

--- a/qa-cd-create.php
+++ b/qa-cd-create.php
@@ -65,9 +65,14 @@ class qa_cd_create_page
 						'label' => 'Categories:',
 						'type' => 'select',
 						'options' => $cat_names,
-						'tags' => 'NAME="catid" ID="catid" onchange="this.form.submit()"',
+						'tags' => 'NAME="catid" ID="catid"',
 					     ),
 					),
+				'buttons' => array(
+					 array(
+						'label' => qa_lang_html('plugin_cat_desc/select'),
+					),
+				),
 				);
 
 		$qa_content['focusid']='catid';


### PR DESCRIPTION
This patch adds a button to validate the form. Without it
the form is auto validated "on change". But it was hence not
possible to select the 1st category from this page.
With this patch is now possible to easily select this category.

Since there is now a button, it becomes counter-intuitive if the
form can be auto-validated, so this patch remove the submit
on-change