### PR TITLE
admin can edit plugin_tag_desc_sidebar_html

### DIFF
--- a/qa-cat-desc-widget.php
+++ b/qa-cat-desc-widget.php
@@ -74,8 +74,10 @@ class qa_cat_descriptions_widget {
 			qa_opt('plugin_cat_desc_max_len', (int)qa_post_text('plugin_cat_desc_ml_field'));
 			qa_opt('plugin_cat_desc_font_size', (int)qa_post_text('plugin_cat_desc_fs_field'));
 			qa_opt('plugin_cat_desc_permit_edit', (int)qa_post_text('plugin_cat_desc_pe_field'));
+			qa_opt('plugin_tag_desc_sidebar_html', (bool)qa_post_text('plugin_cat_desc_sh_check'));
 			$saved=true;
 		}
+
 		return array(
 				'ok' => $saved ? 'Category descriptions settings saved' : null,
 
@@ -94,6 +96,13 @@ class qa_cat_descriptions_widget {
 						'value' => @$permitoptions[qa_opt('plugin_cat_desc_permit_edit')],
 						'options' => $permitoptions,
 						'tags' => 'NAME="plugin_cat_desc_pe_field"',
+					     ),
+
+				    array(
+						'label' => 'Allow html in description',
+						'type' => 'checkbox',
+						'value' => (bool)qa_opt('plugin_tag_desc_sidebar_html'),
+						'tags' => 'NAME="plugin_cat_desc_sh_check"',
 					     ),
 					),
 


### PR DESCRIPTION
The admin form only allows editions of the options `plugin_cat_desc_font_size`
and `plugin_cat_desc_permit_edit`. It's not clear to me how an admin is supposed to
edit the value of the option `plugin_tag_desc_sidebar_html`.
This commit makes it possible to edit this option from the administration dashboard